### PR TITLE
[[링크]] 문법에 [ ] 안나오게

### DIFF
--- a/php-namumark.php
+++ b/php-namumark.php
@@ -267,7 +267,7 @@ class NamuMark {
     }
 
     protected function linkProcessor($text, $type) {
-        if(preg_match('/^((?:http|https|ftp|ftps)\:\/\/\S+)\|(.*)/', $text, $ex_link))
+        if(preg_match('/^((?:http|https|ftp|ftps)\:\/\/\S+)\|?(.*)?/', $text, $ex_link))
             return '['.$ex_link[1].' '.$ex_link[2].']';
         $text = preg_replace('/(https?.*?(\.jpeg|\.jpg|\.png|\.gif))/', '<img src="$1">', $text);
         if(preg_match('/(.*)\|(\[\[파일:.*)\]\]/', $text, $filelink))

--- a/php-namumark.php
+++ b/php-namumark.php
@@ -268,7 +268,12 @@ class NamuMark {
 
     protected function linkProcessor($text, $type) {
         if(preg_match('/^((?:http|https|ftp|ftps)\:\/\/\S+)\|?(.*)?/', $text, $ex_link))
-            return '['.$ex_link[1].' '.$ex_link[2].']';
+        {
+            if(isset($ex_link[2]))
+            	return '['.$ex_link[1].' '.$ex_link[2].']';
+            else
+                return '['.$ex_link[1].']';
+        }
         $text = preg_replace('/(https?.*?(\.jpeg|\.jpg|\.png|\.gif))/', '<img src="$1">', $text);
         if(preg_match('/(.*)\|(\[\[파일:.*)\]\]/', $text, $filelink))
             return $filelink[2].'|link='.str_replace(' ', '_',$filelink[1]).']]';


### PR DESCRIPTION
[참조 링크](http://oriwiki.net/index.php?title=%EC%98%A4%EB%A6%AC%EC%9C%84%ED%82%A4:%EC%97%B0%EC%8A%B5%EC%9E%A5&oldid=8479142)

[http://oriwiki.net/](http://oriwiki.net/)라고 나와야 할것이 `[`[http://oriwiki.net/](http://oriwiki.net/)`]` 라고 나옴